### PR TITLE
Grammar: Hash table

### DIFF
--- a/itsy-bitsy-data-structures.js
+++ b/itsy-bitsy-data-structures.js
@@ -510,7 +510,7 @@ class List {
 \*** ===================================================================== ***/
 
 /**
- * Hash tables are an *unordered*, instead we have "keys" and "values" where we
+ * Hash tables are *unordered*, instead we have "keys" and "values" where we
  * computed an address in memory using the key.
  *
  * The basic idea is that we have keys that are "hashable" (which we'll get to


### PR DESCRIPTION
A small fix:

>Hash tables are ~~an~~ \*unordered\*,