### PR TITLE
Minor grammatical fix

### DIFF
--- a/itsy-bitsy-data-structures.js
+++ b/itsy-bitsy-data-structures.js
@@ -273,7 +273,7 @@
  * where you can store information. You hold onto memory addresses in order to
  * find information.
  *
- * Lets imagine a chunk of memory like this:
+ * Let's imagine a chunk of memory like this:
  *
  *      Values: |1001|0110|1000|0100|0101|1010|0010|0001|1101|1011...
  *   Addresses: 0    1    2    3    4    5    6    7    8    9    ...
@@ -576,7 +576,7 @@ class HashTable {
   }
 
   /**
-   * Next, lets define our "get" function so we have a way of accessing values
+   * Next, let's define our "get" function so we have a way of accessing values
    * by their key.
    *
    * HashTable access is constant O(1) - "AWESOME!!"
@@ -1368,7 +1368,7 @@ class BinarySearchTree {
    */
 
   add(value) {
-    // First lets setup our node.
+    // First let's setup our node.
     var node = {
       value: value,
       left: null,

--- a/itsy-bitsy-data-structures.js
+++ b/itsy-bitsy-data-structures.js
@@ -514,7 +514,7 @@ class List {
  * computed an address in memory using the key.
  *
  * The basic idea is that we have keys that are "hashable" (which we'll get to
- * in a second) and can by used to add, access, and remove from memory very
+ * in a second) and can be used to add, access, and remove from memory very
  * efficiently.
  *
  *     var hashTable = new HashTable();


### PR DESCRIPTION
Lets in this context is used as a contraction of Let us, so should have an apostrophe.