### PR TITLE
Check if the the tree is empty in `Tree#traverse`

### DIFF
--- a/itsy-bitsy-data-structures.js
+++ b/itsy-bitsy-data-structures.js
@@ -1215,6 +1215,11 @@ class Tree {
    */
 
   traverse(callback) {
+    // If the tree is empty, don't do anything.
+    if (this.root === null) {
+      return;
+    }
+
     // We'll define a walk function that we can call recursively on every node
     // in the tree.
     function walk(node) {


### PR DESCRIPTION
Without this check, there would be an error similar to `TypeError: Cannot read property 'children' of null` on line 1224:

https://github.com/jamiebuilds/itsy-bitsy-data-structures/blob/954e7d2faf2dbd5c8710aa03812f10f4bf0e3abf/itsy-bitsy-data-structures.js#L1224